### PR TITLE
Refactor voice synth audio integration

### DIFF
--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -19,7 +19,7 @@ Button *blackout_btn = nullptr;
 Button *btn48v = nullptr;
 Button *inverter_btn = nullptr;
 
-void UI::init() {
+void UI::init(AudioClass &audio) {
   Serial.print("Initializing UI...");
 
   canvas = lv_scr_act();
@@ -72,7 +72,9 @@ void UI::init() {
 
   lv_obj_set_tile_id(tiles, 2, 0, LV_ANIM_OFF); // start on voice tile
 
-  voice_anim_timer = lv_timer_create(voice_anim_cb, 50, nullptr);
+  // Pass the audio instance to the animation timer so the callback can query
+  // its playback state.
+  voice_anim_timer = lv_timer_create(voice_anim_cb, 50, &audio);
   // Slow down gauge animations so they are less frenetic
   gauge_anim_timer = lv_timer_create(gauge_anim_cb, 150, nullptr);
 

--- a/src/UI.h
+++ b/src/UI.h
@@ -6,6 +6,7 @@
 class ButtonPanel;
 class VoiceTile;
 class GaugeTile;
+class AudioClass;
 
 class UI {
   lv_obj_t *canvas = nullptr;
@@ -19,7 +20,7 @@ class UI {
   lv_timer_t *gauge_anim_timer = nullptr;
 
 public:
-  void init();
+  void init(AudioClass &audio);
   VoiceTile *getVoiceTile() const { return voiceTile; }
   ButtonPanel *getLeftPanel() const { return leftPanel; }
   ButtonPanel *getRightPanel() const { return rightPanel; }

--- a/src/voice_synth.cpp
+++ b/src/voice_synth.cpp
@@ -2,7 +2,14 @@
 
 #include "config.h"
 #include "voice_tile.h"
-// TODO: Removed audio_helper include; audio playback status disabled.
+// Provide access to the audio player.  The real header lives in the
+// GigaAudio library but may not be present when building the UI in
+// isolation.  A forward declaration is provided in ``voice_synth.h``.
+#if __has_include(<Arduino_GigaAudio.h>)
+#  include <Arduino_GigaAudio.h>
+#elif __has_include(<GigaAudio.h>)
+#  include <GigaAudio.h>
+#endif
 #include <stdlib.h>
 
 void voice_anim_cb(lv_timer_t *t) {
@@ -10,8 +17,8 @@ void voice_anim_cb(lv_timer_t *t) {
   static float target = 0.f;
   static int hold = 0;
   static bool was_playing = false;
-  (void)t;
-  bool playing = false; // TODO: Determine playing state when audio helper is available
+  AudioClass *audio = t ? static_cast<AudioClass *>(t->user_data) : nullptr;
+  bool playing = audio && audio->isPlaying();
 
   if (!playing) {
     if (was_playing && voiceTile) {

--- a/src/voice_synth.h
+++ b/src/voice_synth.h
@@ -3,6 +3,12 @@
 
 #include "lvgl_wrapper.h"
 
+// Forward declaration from the GigaAudio library
+class AudioClass;
+
+/// Timer callback used to drive the voice visualiser.
+/// The timer's user data must point to an ``AudioClass`` instance so that
+/// the callback can query the current playback state.
 void voice_anim_cb(lv_timer_t *t);
 
 #endif


### PR DESCRIPTION
## Summary
- allow voice synthesizer to get playback info from the GigaAudio object
- store audio reference via timer userdata
- update UI initialisation to pass the audio object

## Testing
- `g++ -std=c++17 -I./src -c src/voice_synth.cpp -o /tmp/voice_synth.o` *(fails: lv_conf.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c887e171c8329af0bcd4826f1f345