### PR TITLE
Add audio stop event for AUD indicator

### DIFF
--- a/src/UI.cpp
+++ b/src/UI.cpp
@@ -35,7 +35,7 @@ void UI::init(GigaAudio &audio) {
   ::leftGaugeTile = leftGaugeTile;
 
   leftPanel = ButtonPanel::createTile(tiles, 1, button_panel1);
-  voiceTile = new VoiceTile(tiles, 2, voice_buttons);
+  voiceTile = new VoiceTile(tiles, 2, voice_buttons, &audio);
   ::voiceTile = voiceTile;
   for (int i = 0; i < 3; ++i) {
     Button *btn = voiceTile->getButton(i);

--- a/src/voice_tile.cpp
+++ b/src/voice_tile.cpp
@@ -1,13 +1,18 @@
 #include "voice_tile.h"
 #include "config.h"
+#include <GigaAudio.h>
 
-// TODO: Audio stop functionality removed along with audio_helper.
-
-// TODO: removed audio stop event callback (aud_event_cb) pending
-// reintroduction of audio functionality.
+static void aud_event_cb(lv_event_t *e) {
+  auto audio = static_cast<GigaAudio *>(lv_event_get_user_data(e));
+  if (!audio)
+    return;
+  lv_event_code_t code = lv_event_get_code(e);
+  if (code == LV_EVENT_CLICKED)
+    audio->stop();
+}
 
 VoiceTile::VoiceTile(lv_obj_t *tileview, int row_id,
-                     ButtonData const *button_data) {
+                     ButtonData const *button_data, GigaAudio *audio) {
   tile = lv_tileview_add_tile(tileview, row_id, 0, LV_DIR_HOR);
   lv_obj_set_style_bg_color(tile, BLACK, 0);
   // Tile itself shouldn't be scrollable
@@ -54,8 +59,10 @@ VoiceTile::VoiceTile(lv_obj_t *tileview, int row_id,
     }
   }
 
-  // TODO: Previously added event to stop audio when AUD indicator was pressed.
-  // Functionality removed with audio_helper removal.
+  if (audio && indicators[0]) {
+    lv_obj_add_event_cb(indicators[0]->getObj(), aud_event_cb, LV_EVENT_CLICKED,
+                        audio);
+  }
 
   visualiser = new VoiceVisualiser(grid);
 

--- a/src/voice_tile.h
+++ b/src/voice_tile.h
@@ -6,6 +6,8 @@
 #include "voice_visualiser.h"
 #include "lvgl_wrapper.h"
 
+class GigaAudio;
+
 class VoiceTile {
   lv_obj_t *tile;
   lv_obj_t *grid;
@@ -14,7 +16,8 @@ class VoiceTile {
   Button *buttons[3];
 
 public:
-  VoiceTile(lv_obj_t *tileview, int row_id, ButtonData const *button_data);
+  VoiceTile(lv_obj_t *tileview, int row_id, ButtonData const *button_data,
+            GigaAudio *audio);
 
   lv_obj_t *getTile() const { return tile; }
   VoiceVisualiser *getVisualiser() const { return visualiser; }


### PR DESCRIPTION
## Summary
- pass audio player to `VoiceTile`
- stop audio playback when clicking the AUD indicator

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_684cbf908e98832981c578a85175e94b